### PR TITLE
Expose splashColor property for buttons.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ TwitterSignInButton(
 )
 ```
 
+You can adjust the splash color of the buttons:
+
+```dart
+GoogleSignInButton(
+  onPressed: () {/* ... */}, 
+  splashColor: Colors.white, 
+  // setting splashColor to Colors.transparent will remove button ripple effect.
+)
+```
+
 See the documentation for API details: https://pub.dartlang.org/documentation/flutter_auth_buttons/latest/.
 
 ## Contributions

--- a/lib/src/apple.dart
+++ b/lib/src/apple.dart
@@ -12,6 +12,7 @@ class AppleSignInButton extends StatelessWidget {
   final double borderRadius;
   final VoidCallback onPressed;
   final TextStyle textStyle;
+  final Color splashColor;
 
   /// Creates a new button. Set [darkMode] to `true` to use the dark
   /// black background variant with white text, otherwise an all-white background
@@ -21,6 +22,7 @@ class AppleSignInButton extends StatelessWidget {
       // 'Continue with Apple' is also an available variant depdening on App's sign-in experience.
       this.text = 'Sign in with Apple',
       this.textStyle,
+      this.splashColor,
       this.style = AppleButtonStyle.white,
       // Apple doesn't specify a border radius, but this looks about right.
       this.borderRadius = defaultBorderRadius,
@@ -34,6 +36,7 @@ class AppleSignInButton extends StatelessWidget {
       buttonColor:
           style == AppleButtonStyle.black ? Colors.black : Colors.white,
       borderRadius: borderRadius,
+      splashColor: splashColor,
       buttonBorderColor:
           style == AppleButtonStyle.whiteOutline ? Colors.black : null,
       onPressed: onPressed,

--- a/lib/src/button.dart
+++ b/lib/src/button.dart
@@ -6,7 +6,7 @@ class StretchableButton extends StatelessWidget {
   final VoidCallback onPressed;
   final double borderRadius;
   final double buttonPadding;
-  final Color buttonColor;
+  final Color buttonColor, splashColor;
   final Color buttonBorderColor;
   final List<Widget> children;
 
@@ -14,6 +14,7 @@ class StretchableButton extends StatelessWidget {
     @required this.buttonColor,
     @required this.borderRadius,
     @required this.children,
+    this.splashColor,
     this.buttonBorderColor,
     this.onPressed,
     this.buttonPadding,
@@ -50,6 +51,7 @@ class StretchableButton extends StatelessWidget {
           child: RaisedButton(
             onPressed: onPressed,
             color: buttonColor,
+            splashColor: splashColor,
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: contents,

--- a/lib/src/facebook.dart
+++ b/lib/src/facebook.dart
@@ -11,6 +11,7 @@ class FacebookSignInButton extends StatelessWidget {
   final TextStyle textStyle;
   final VoidCallback onPressed;
   final double borderRadius;
+  final Color splashColor;
 
   /// Creates a new button. The default button text is 'Continue with Facebook',
   /// which apparently results in higher conversion. 'Login with Facebook' is
@@ -20,6 +21,7 @@ class FacebookSignInButton extends StatelessWidget {
     this.borderRadius = defaultBorderRadius,
     this.text = 'Continue with Facebook',
     this.textStyle,
+    this.splashColor,
     Key key,
   })  : assert(text != null),
         super(key: key);
@@ -29,6 +31,7 @@ class FacebookSignInButton extends StatelessWidget {
     return StretchableButton(
       buttonColor: Color(0xFF4267B2),
       borderRadius: borderRadius,
+      splashColor: splashColor,
       onPressed: onPressed,
       buttonPadding: 8.0,
       children: <Widget>[

--- a/lib/src/google.dart
+++ b/lib/src/google.dart
@@ -12,6 +12,7 @@ class GoogleSignInButton extends StatelessWidget {
   final bool darkMode;
   final double borderRadius;
   final VoidCallback onPressed;
+  final Color splashColor;
 
   /// Creates a new button. Set [darkMode] to `true` to use the dark
   /// blue background variant with white text, otherwise an all-white background
@@ -20,6 +21,7 @@ class GoogleSignInButton extends StatelessWidget {
       {this.onPressed,
       this.text = 'Sign in with Google',
       this.textStyle,
+      this.splashColor,
       this.darkMode = false,
       // Google doesn't specify a border radius, but this looks about right.
       this.borderRadius = defaultBorderRadius,
@@ -32,6 +34,7 @@ class GoogleSignInButton extends StatelessWidget {
     return StretchableButton(
       buttonColor: darkMode ? Color(0xFF4285F4) : Colors.white,
       borderRadius: borderRadius,
+      splashColor: splashColor,
       onPressed: onPressed,
       buttonPadding: 0.0,
       children: <Widget>[

--- a/lib/src/microsoft.dart
+++ b/lib/src/microsoft.dart
@@ -8,6 +8,7 @@ class MicrosoftSignInButton extends StatelessWidget {
   final VoidCallback onPressed;
   final double borderRadius;
   final bool darkMode;
+  final Color splashColor;
 
   /// Creates a new button. The default button text is 'Sign in with Microsoft'.
   /// Microsoft also allows simply 'Sign in'.
@@ -17,6 +18,7 @@ class MicrosoftSignInButton extends StatelessWidget {
     this.text = 'Sign in with Microsoft',
     this.textStyle,
     this.darkMode = false,
+    this.splashColor,
     Key key,
   })  : assert(text != null),
         super(key: key);
@@ -26,6 +28,7 @@ class MicrosoftSignInButton extends StatelessWidget {
     return StretchableButton(
       buttonColor: darkMode ? Color(0xFF2F2F2F) : Color(0xFFFFFFFF),
       borderRadius: borderRadius,
+      splashColor: splashColor,
       buttonBorderColor: darkMode ? null : Color(0xFF8C8C8C),
       onPressed: onPressed,
       buttonPadding: 10.0, // This is an estimate

--- a/lib/src/twitter.dart
+++ b/lib/src/twitter.dart
@@ -11,6 +11,7 @@ class TwitterSignInButton extends StatelessWidget {
   final TextStyle textStyle;
   final VoidCallback onPressed;
   final double borderRadius;
+  final Color splashColor;
 
   /// Creates a new button. The default button text is 'Sign in with Twitter'.
   TwitterSignInButton({
@@ -18,6 +19,7 @@ class TwitterSignInButton extends StatelessWidget {
     this.borderRadius = defaultBorderRadius,
     this.text = 'Sign in with Twitter',
     this.textStyle,
+    this.splashColor,
     Key key,
   })  : assert(text != null),
         super(key: key);
@@ -27,6 +29,7 @@ class TwitterSignInButton extends StatelessWidget {
     return StretchableButton(
       buttonColor: Color(0xFFE7E7E7),
       borderRadius: borderRadius,
+      splashColor: splashColor,
       onPressed: onPressed,
       buttonBorderColor: Color(0xFFCCCCCC),
       buttonPadding: 0.0,

--- a/test/facebook_test.dart
+++ b/test/facebook_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_auth_buttons/src/button.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_auth_buttons/flutter_auth_buttons.dart';
 
@@ -94,5 +95,40 @@ void main() {
 
     final FacebookSignInButton button = tester.firstWidget(find.byType(FacebookSignInButton));
     expect(button.textStyle, suppliedTextStyle);
+  });
+
+  testWidgets('Check supplied splash color is used', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: FacebookSignInButton(
+            onPressed: () {},
+            splashColor: Colors.white,
+          ),
+        ),
+      ),
+    );
+
+    var button = find.byType(StretchableButton).evaluate().toList()[0].widget as StretchableButton;
+    expect(button.splashColor, Colors.white);
+  });
+
+  testWidgets('Check default splash color is used', (WidgetTester tester) async {
+    ButtonThemeData buttonTheme;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (BuildContext context) {
+            buttonTheme = ButtonTheme.of(context);
+            return FacebookSignInButton(
+              onPressed: () {},
+            );
+          },
+        ),
+      ));
+
+    var button = find.byType(RaisedButton).evaluate().toList()[0].widget as RaisedButton;
+    expect(buttonTheme.getSplashColor(button), buttonTheme.getTextColor(button).withOpacity(0.12));
   });
 }

--- a/test/google_test.dart
+++ b/test/google_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_auth_buttons/src/button.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_auth_buttons/flutter_auth_buttons.dart';
 
@@ -138,5 +139,40 @@ void main() {
 
     final GoogleSignInButton button = tester.firstWidget(find.byType(GoogleSignInButton));
     expect(button.textStyle, suppliedTextStyle);
+  });
+
+  testWidgets('Check supplied splash color is used', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: GoogleSignInButton(
+            onPressed: () {},
+            splashColor: Colors.white,
+          ),
+        ),
+      ),
+    );
+
+    var button = find.byType(StretchableButton).evaluate().toList()[0].widget as StretchableButton;
+    expect(button.splashColor, Colors.white);
+  });
+
+  testWidgets('Check default splash color is used', (WidgetTester tester) async {
+    ButtonThemeData buttonTheme;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (BuildContext context) {
+            buttonTheme = ButtonTheme.of(context);
+            return GoogleSignInButton(
+              onPressed: () {},
+            );
+          },
+        ),
+      ));
+
+    var button = find.byType(RaisedButton).evaluate().toList()[0].widget as RaisedButton;
+    expect(buttonTheme.getSplashColor(button), buttonTheme.getTextColor(button).withOpacity(0.12));
   });
 }

--- a/test/twitter_test.dart
+++ b/test/twitter_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_auth_buttons/src/button.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_auth_buttons/flutter_auth_buttons.dart';
 
@@ -93,5 +94,40 @@ void main() {
 
     final TwitterSignInButton button = tester.firstWidget(find.byType(TwitterSignInButton));
     expect(button.textStyle, suppliedTextStyle);
+  });
+
+  testWidgets('Check supplied splash color is used', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: TwitterSignInButton(
+            onPressed: () {},
+            splashColor: Colors.white,
+          ),
+        ),
+      ),
+    );
+
+    var button = find.byType(StretchableButton).evaluate().toList()[0].widget as StretchableButton;
+    expect(button.splashColor, Colors.white);
+  });
+
+  testWidgets('Check default splash color is used', (WidgetTester tester) async {
+    ButtonThemeData buttonTheme;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (BuildContext context) {
+            buttonTheme = ButtonTheme.of(context);
+            return TwitterSignInButton(
+              onPressed: () {},
+            );
+          },
+        ),
+      ));
+
+    var button = find.byType(RaisedButton).evaluate().toList()[0].widget as RaisedButton;
+    expect(buttonTheme.getSplashColor(button), buttonTheme.getTextColor(button).withOpacity(0.12));
   });
 }


### PR DESCRIPTION
This will allow the splashColor to be set. One major benefit to this is the ability remove the ripple effect from the buttons if desired. This can be done by setting splashColor to Colors.transparent. I also updated the tests and the README.