### PR TITLE
Fix CI errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 
 before_script:
   - cd ..
-  - git clone https://github.com/flutter/flutter.git
+  - git clone https://github.com/flutter/flutter.git -b stable
   - export PATH=`pwd`/flutter/bin:`pwd`/flutter/bin/cache/dart-sdk/bin:$PATH
   - flutter doctor
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.7.0
 homepage: https://github.com/dmjones/flutter_auth_buttons
 
 environment:
-  sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  sdk: ">=2.0.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Move to Flutter stable branch to avoid triggering publishing errors in CI.