### PR TITLE
Add expanded attribute for buttons

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -18,30 +18,29 @@ class MyApp extends StatelessWidget {
         ),
         backgroundColor: Color.fromARGB(0xFF, 0xF0, 0xF0, 0xF0),
         body: SingleChildScrollView(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: <Widget>[
-              Column(
-                children: <Widget>[
-                  SizedBox(height: padding),
-                  AppleSignInButton(onPressed: () {}),
-                  AppleSignInButton(
-                      onPressed: () {}, style: AppleButtonStyle.whiteOutline),
-                  AppleSignInButton(
-                      onPressed: () {}, style: AppleButtonStyle.black),
-                  SizedBox(height: padding),
-                  GoogleSignInButton(onPressed: () {}),
-                  GoogleSignInButton(onPressed: () {}, darkMode: true),
-                  SizedBox(height: padding),
-                  FacebookSignInButton(onPressed: () {}),
-                  SizedBox(height: padding),
-                  TwitterSignInButton(onPressed: () {}),
-                  SizedBox(height: padding),
-                  MicrosoftSignInButton(onPressed: () {}),
-                  MicrosoftSignInButton(onPressed: () {}, darkMode: true),
-                ],
-              ),
-            ],
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 15.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                SizedBox(height: padding),
+                AppleSignInButton(expanded: true, onPressed: () {}),
+                AppleSignInButton(expanded: true,
+                    onPressed: () {}, style: AppleButtonStyle.whiteOutline),
+                AppleSignInButton(expanded: true,
+                    onPressed: () {}, style: AppleButtonStyle.black),
+                SizedBox(height: padding),
+                GoogleSignInButton(expanded: true, onPressed: () {}),
+                GoogleSignInButton(expanded: true, onPressed: () {}, darkMode: true),
+                SizedBox(height: padding),
+                FacebookSignInButton(expanded: true, onPressed: () {}),
+                SizedBox(height: padding),
+                TwitterSignInButton(expanded: true, onPressed: () {}),
+                SizedBox(height: padding),
+                MicrosoftSignInButton(expanded: true, onPressed: () {}),
+                MicrosoftSignInButton(expanded: true, onPressed: () {}, darkMode: true),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/src/apple.dart
+++ b/lib/src/apple.dart
@@ -13,6 +13,7 @@ class AppleSignInButton extends StatelessWidget {
   final VoidCallback onPressed;
   final TextStyle textStyle;
   final Color splashColor;
+  final bool expanded;
 
   /// Creates a new button. Set [darkMode] to `true` to use the dark
   /// black background variant with white text, otherwise an all-white background
@@ -24,6 +25,7 @@ class AppleSignInButton extends StatelessWidget {
       this.textStyle,
       this.splashColor,
       this.style = AppleButtonStyle.white,
+      this.expanded = false,
       // Apple doesn't specify a border radius, but this looks about right.
       this.borderRadius = defaultBorderRadius,
       Key key})
@@ -41,6 +43,7 @@ class AppleSignInButton extends StatelessWidget {
           style == AppleButtonStyle.whiteOutline ? Colors.black : null,
       onPressed: onPressed,
       buttonPadding: 0.0,
+      expanded: expanded,
       children: <Widget>[
         Center(
           child: Row(

--- a/lib/src/button.dart
+++ b/lib/src/button.dart
@@ -9,6 +9,7 @@ class StretchableButton extends StatelessWidget {
   final Color buttonColor, splashColor;
   final Color buttonBorderColor;
   final List<Widget> children;
+  final bool expanded;
 
   StretchableButton({
     @required this.buttonColor,
@@ -18,6 +19,7 @@ class StretchableButton extends StatelessWidget {
     this.buttonBorderColor,
     this.onPressed,
     this.buttonPadding,
+    this.expanded=false,
   });
 
   @override
@@ -53,7 +55,7 @@ class StretchableButton extends StatelessWidget {
             color: buttonColor,
             splashColor: splashColor,
             child: Row(
-              mainAxisSize: MainAxisSize.min,
+              mainAxisSize: expanded ? MainAxisSize.max : MainAxisSize.min,
               children: contents,
             ),
           ),

--- a/lib/src/facebook.dart
+++ b/lib/src/facebook.dart
@@ -12,6 +12,7 @@ class FacebookSignInButton extends StatelessWidget {
   final VoidCallback onPressed;
   final double borderRadius;
   final Color splashColor;
+  final bool expanded;
 
   /// Creates a new button. The default button text is 'Continue with Facebook',
   /// which apparently results in higher conversion. 'Login with Facebook' is
@@ -22,6 +23,7 @@ class FacebookSignInButton extends StatelessWidget {
     this.text = 'Continue with Facebook',
     this.textStyle,
     this.splashColor,
+    this.expanded = false,
     Key key,
   })  : assert(text != null),
         super(key: key);
@@ -33,6 +35,7 @@ class FacebookSignInButton extends StatelessWidget {
       borderRadius: borderRadius,
       splashColor: splashColor,
       onPressed: onPressed,
+      expanded: expanded,
       buttonPadding: 8.0,
       children: <Widget>[
         // Facebook doesn't provide strict sizes, so this is a good

--- a/lib/src/google.dart
+++ b/lib/src/google.dart
@@ -13,6 +13,7 @@ class GoogleSignInButton extends StatelessWidget {
   final double borderRadius;
   final VoidCallback onPressed;
   final Color splashColor;
+  final bool expanded;
 
   /// Creates a new button. Set [darkMode] to `true` to use the dark
   /// blue background variant with white text, otherwise an all-white background
@@ -23,6 +24,7 @@ class GoogleSignInButton extends StatelessWidget {
       this.textStyle,
       this.splashColor,
       this.darkMode = false,
+      this.expanded = false,
       // Google doesn't specify a border radius, but this looks about right.
       this.borderRadius = defaultBorderRadius,
       Key key})
@@ -36,6 +38,7 @@ class GoogleSignInButton extends StatelessWidget {
       borderRadius: borderRadius,
       splashColor: splashColor,
       onPressed: onPressed,
+      expanded: expanded,
       buttonPadding: 0.0,
       children: <Widget>[
         // The Google design guidelines aren't consistent. The dark mode

--- a/lib/src/microsoft.dart
+++ b/lib/src/microsoft.dart
@@ -9,6 +9,7 @@ class MicrosoftSignInButton extends StatelessWidget {
   final double borderRadius;
   final bool darkMode;
   final Color splashColor;
+  final bool expanded;
 
   /// Creates a new button. The default button text is 'Sign in with Microsoft'.
   /// Microsoft also allows simply 'Sign in'.
@@ -19,6 +20,7 @@ class MicrosoftSignInButton extends StatelessWidget {
     this.textStyle,
     this.darkMode = false,
     this.splashColor,
+    this.expanded = false,
     Key key,
   })  : assert(text != null),
         super(key: key);
@@ -31,6 +33,7 @@ class MicrosoftSignInButton extends StatelessWidget {
       splashColor: splashColor,
       buttonBorderColor: darkMode ? null : Color(0xFF8C8C8C),
       onPressed: onPressed,
+      expanded: expanded,
       buttonPadding: 10.0, // This is an estimate
       children: <Widget>[
         Padding(

--- a/lib/src/twitter.dart
+++ b/lib/src/twitter.dart
@@ -12,6 +12,7 @@ class TwitterSignInButton extends StatelessWidget {
   final VoidCallback onPressed;
   final double borderRadius;
   final Color splashColor;
+  final bool expanded;
 
   /// Creates a new button. The default button text is 'Sign in with Twitter'.
   TwitterSignInButton({
@@ -20,6 +21,7 @@ class TwitterSignInButton extends StatelessWidget {
     this.text = 'Sign in with Twitter',
     this.textStyle,
     this.splashColor,
+    this.expanded = false,
     Key key,
   })  : assert(text != null),
         super(key: key);
@@ -32,6 +34,7 @@ class TwitterSignInButton extends StatelessWidget {
       splashColor: splashColor,
       onPressed: onPressed,
       buttonBorderColor: Color(0xFFCCCCCC),
+      expanded: expanded,
       buttonPadding: 0.0,
       children: <Widget>[
         // Facebook doesn't provide strict sizes, so this is a good


### PR DESCRIPTION
Closes #31 

It looks terrible when all buttons have different sizes. This PR adds an attribute `expanded` to each of them that allows expansion along the horizontal axis to max.

<img src="https://user-images.githubusercontent.com/14923964/88979583-487f1d80-d2c2-11ea-8281-4c4ed2213649.png" data-canonical-src="https://user-images.githubusercontent.com/14923964/88979583-487f1d80-d2c2-11ea-8281-4c4ed2213649.png" height="500" />