### PR TITLE
Added attribute to center button contents

### DIFF
--- a/lib/src/apple.dart
+++ b/lib/src/apple.dart
@@ -13,6 +13,7 @@ class AppleSignInButton extends StatelessWidget {
   final VoidCallback onPressed;
   final TextStyle textStyle;
   final Color splashColor;
+  final bool contentsCentered;
 
   /// Creates a new button. Set [darkMode] to `true` to use the dark
   /// black background variant with white text, otherwise an all-white background
@@ -26,6 +27,7 @@ class AppleSignInButton extends StatelessWidget {
       this.style = AppleButtonStyle.white,
       // Apple doesn't specify a border radius, but this looks about right.
       this.borderRadius = defaultBorderRadius,
+      this.contentsCentered = false,
       Key key})
       : assert(text != null),
         super(key: key);
@@ -41,6 +43,7 @@ class AppleSignInButton extends StatelessWidget {
           style == AppleButtonStyle.whiteOutline ? Colors.black : null,
       onPressed: onPressed,
       buttonPadding: 0.0,
+      contentsCentered: contentsCentered,
       children: <Widget>[
         Center(
           child: Row(

--- a/lib/src/button.dart
+++ b/lib/src/button.dart
@@ -9,6 +9,7 @@ class StretchableButton extends StatelessWidget {
   final Color buttonColor, splashColor;
   final Color buttonBorderColor;
   final List<Widget> children;
+  final bool contentsCentered;
 
   StretchableButton({
     @required this.buttonColor,
@@ -18,6 +19,7 @@ class StretchableButton extends StatelessWidget {
     this.buttonBorderColor,
     this.onPressed,
     this.buttonPadding,
+    this.contentsCentered = false,
   });
 
   @override
@@ -29,6 +31,9 @@ class StretchableButton extends StatelessWidget {
         if (constraints.minWidth == 0) {
           contents.add(SizedBox.shrink());
         } else {
+          if (contentsCentered) {
+            contents.insert(0, Spacer());
+          }
           contents.add(Spacer());
         }
 

--- a/lib/src/facebook.dart
+++ b/lib/src/facebook.dart
@@ -12,6 +12,7 @@ class FacebookSignInButton extends StatelessWidget {
   final VoidCallback onPressed;
   final double borderRadius;
   final Color splashColor;
+  final bool contentsCentered;
 
   /// Creates a new button. The default button text is 'Continue with Facebook',
   /// which apparently results in higher conversion. 'Login with Facebook' is
@@ -22,6 +23,7 @@ class FacebookSignInButton extends StatelessWidget {
     this.text = 'Continue with Facebook',
     this.textStyle,
     this.splashColor,
+    this.contentsCentered = false,
     Key key,
   })  : assert(text != null),
         super(key: key);
@@ -34,6 +36,7 @@ class FacebookSignInButton extends StatelessWidget {
       splashColor: splashColor,
       onPressed: onPressed,
       buttonPadding: 8.0,
+      contentsCentered: contentsCentered,
       children: <Widget>[
         // Facebook doesn't provide strict sizes, so this is a good
         // estimate of their examples within documentation.

--- a/lib/src/google.dart
+++ b/lib/src/google.dart
@@ -13,6 +13,7 @@ class GoogleSignInButton extends StatelessWidget {
   final double borderRadius;
   final VoidCallback onPressed;
   final Color splashColor;
+  final bool contentsCentered;
 
   /// Creates a new button. Set [darkMode] to `true` to use the dark
   /// blue background variant with white text, otherwise an all-white background
@@ -25,6 +26,7 @@ class GoogleSignInButton extends StatelessWidget {
       this.darkMode = false,
       // Google doesn't specify a border radius, but this looks about right.
       this.borderRadius = defaultBorderRadius,
+      this.contentsCentered = false,
       Key key})
       : assert(text != null),
         super(key: key);
@@ -37,6 +39,7 @@ class GoogleSignInButton extends StatelessWidget {
       splashColor: splashColor,
       onPressed: onPressed,
       buttonPadding: 0.0,
+      contentsCentered: contentsCentered,
       children: <Widget>[
         // The Google design guidelines aren't consistent. The dark mode
         // seems to have a perfect square of white around the logo, with a

--- a/lib/src/microsoft.dart
+++ b/lib/src/microsoft.dart
@@ -9,6 +9,7 @@ class MicrosoftSignInButton extends StatelessWidget {
   final double borderRadius;
   final bool darkMode;
   final Color splashColor;
+  final bool contentsCentered;
 
   /// Creates a new button. The default button text is 'Sign in with Microsoft'.
   /// Microsoft also allows simply 'Sign in'.
@@ -19,6 +20,7 @@ class MicrosoftSignInButton extends StatelessWidget {
     this.textStyle,
     this.darkMode = false,
     this.splashColor,
+    this.contentsCentered = false,
     Key key,
   })  : assert(text != null),
         super(key: key);
@@ -32,6 +34,7 @@ class MicrosoftSignInButton extends StatelessWidget {
       buttonBorderColor: darkMode ? null : Color(0xFF8C8C8C),
       onPressed: onPressed,
       buttonPadding: 10.0, // This is an estimate
+      contentsCentered: contentsCentered,
       children: <Widget>[
         Padding(
           padding: const EdgeInsets.only(left: 2.0), // adds to 10 to make 12

--- a/lib/src/twitter.dart
+++ b/lib/src/twitter.dart
@@ -12,6 +12,7 @@ class TwitterSignInButton extends StatelessWidget {
   final VoidCallback onPressed;
   final double borderRadius;
   final Color splashColor;
+  final bool contentsCentered;
 
   /// Creates a new button. The default button text is 'Sign in with Twitter'.
   TwitterSignInButton({
@@ -20,6 +21,7 @@ class TwitterSignInButton extends StatelessWidget {
     this.text = 'Sign in with Twitter',
     this.textStyle,
     this.splashColor,
+    this.contentsCentered = false,
     Key key,
   })  : assert(text != null),
         super(key: key);
@@ -33,6 +35,7 @@ class TwitterSignInButton extends StatelessWidget {
       onPressed: onPressed,
       buttonBorderColor: Color(0xFFCCCCCC),
       buttonPadding: 0.0,
+      contentsCentered: contentsCentered,
       children: <Widget>[
         // Facebook doesn't provide strict sizes, so this is a good
         // estimate of their examples within documentation.


### PR DESCRIPTION
Added a simple attribute to the StretchableButton widget to allow for centering of the button contents as the buttons expand.
- I left the default behavior not centered and the attribute false to maintain compatibility.
- I also updated the current library of auth buttons to work with this change.
- Tested within my own project and behaves like original package with new functionality
- Not sure if any documentation changes are needed as it is an easily found attribute for the widgets, open to discussion and revision of current documentation if needed.

Fixes #31 