### PR TITLE
Increase the font and icon size for the Sign in with Apple button.

### DIFF
--- a/lib/src/apple.dart
+++ b/lib/src/apple.dart
@@ -62,8 +62,8 @@ class AppleSignInButton extends StatelessWidget {
                         "graphics/apple_logo_${style == AppleButtonStyle.black ? "white" : "black"}.png",
                         package: "flutter_auth_buttons",
                       ),
-                      height: 17.0,
-                      width: 17.0,
+                      height: 24.0,
+                      width: 24.0,
                     ),
                   ),
                 ),
@@ -74,7 +74,7 @@ class AppleSignInButton extends StatelessWidget {
                   text,
                   style: textStyle ??
                       TextStyle(
-                        fontSize: 16.0,
+                        fontSize: 18.0,
                         fontFamily: "SF Pro",
                         fontWeight: FontWeight.w500,
                         color: style == AppleButtonStyle.black


### PR DESCRIPTION
I increased the font and icon size for the Sign in with Apple button, so that it is the same as for the other sign in buttons. This is in response to Apple rejecting an update to my app because of the 'Sign in with Apple' button having a slightly smaller font than the buttons for the other social login providers.

This is their exact response:
```
Your app uses Sign in with Apple as a login option but does not use the appropriate Sign in with Apple button design, branding, and/or user interface elements as described in the Sign in With Apple Human Interface Guidelines. Specifically:

- Your Sign in with Apple button is not displayed as prominently in your app as other sign in buttons.

Next Steps

To resolve this issue, revise the Sign in with Apple button design, branding and/or user interface elements in your app so that it follows all the Sign in With Apple Human Interface Guidelines.
```